### PR TITLE
Cache faucet_config_table_names to avoid long delay

### DIFF
--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -152,8 +152,8 @@ def import_hw_config():
                     valid_types, config_file_name))
                 sys.exit(-1)
         dp_ports = config['dp_ports']
-        if len(dp_ports) != REQUIRED_TEST_PORTS:
-            print('Exactly %u dataplane ports are required, '
+        if len(dp_ports) < REQUIRED_TEST_PORTS:
+            print('At least %u dataplane ports are required, '
                   '%d are provided in %s.' %
                   (REQUIRED_TEST_PORTS, len(dp_ports), config_file_name))
             sys.exit(-1)

--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -680,6 +680,10 @@ def parse_args():
         '-d', '--dumpfail', action='store_true', help='dump logs for failed tests')
     parser.add_argument(
         '-k', '--keep_logs', action='store_true', help='keep logs even for OK tests')
+    loglevels = ('debug', 'error', 'warning', 'info', 'output')
+    parser.add_argument(
+        '-l', '--loglevel', choices=loglevels, default='warning',
+        help='set mininet logging level')
     parser.add_argument(
         '-n', '--nocheck', action='store_true', help='skip dependency check')
     parser.add_argument(
@@ -722,16 +726,19 @@ def parse_args():
     return (
         requested_test_classes, args.clean, args.dumpfail,
         args.keep_logs, args.nocheck, args.serial, args.repeat,
-        excluded_test_classes, report_json_filename, port_order)
+        excluded_test_classes, report_json_filename, port_order,
+        args.loglevel)
 
 
 def test_main(module):
     """Test main."""
-    setLogLevel('error')
     print('testing module %s' % module)
 
     (requested_test_classes, clean, dumpfail, keep_logs, nocheck,
-     serial, repeat, excluded_test_classes, report_json_filename, port_order) = parse_args()
+     serial, repeat, excluded_test_classes, report_json_filename, port_order,
+     loglevel) = parse_args()
+
+    setLogLevel(loglevel)
 
     if clean:
         print('Cleaning up test interfaces, processes and openvswitch '

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -9,7 +9,7 @@ set -e  # quit on error
 
 # allow user to skip parts of docker test
 # this wrapper script only cares about -n, -u, -i, others passed to test suite.
-while getopts "cdijknrsuxoz" o $FAUCET_TESTS; do
+while getopts "cdijknrsuxozl" o $FAUCET_TESTS; do
   case "${o}" in
         i)
             # run only integration tests

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -303,6 +303,7 @@ configuration.
         self.stack_root_name = None
         self.stack_roots_names = None
         self.stack_route_learning = None
+        self.stack_root_flood_reflection = None
 
         self.acls = {}
         self.vlans = {}
@@ -799,6 +800,9 @@ configuration.
                 path_to_root_len = len(self.shortest_path(self.stack_root_name, src_dp=dp))
                 test_config_condition(
                     path_to_root_len == 0, '%s not connected to stack' % dp)
+
+            if self.stack_longest_path_to_root_len() > 2:
+                self.stack_root_flood_reflection = True
 
         if self.tunnel_acls:
             self.finalize_tunnel_acls(dps)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -193,7 +193,7 @@ class Valve:
                 self.dp.combinatorial_port_flood, self.dp.canonical_port_order,
                 self.dp.stack_ports, self.dp.has_externals,
                 self.dp.shortest_path_to_root, self.dp.shortest_path_port,
-                self.dp.stack_longest_path_to_root_len, self.dp.is_stack_root,
+                self.dp.stack_root_flood_reflection, self.dp.is_stack_root,
                 self.dp.is_stack_root_candidate, self.dp.stack.get('graph', None))
         else:
             self.flood_manager = valve_flood.ValveFloodManager(
@@ -210,7 +210,7 @@ class Valve:
             self.dp.tables['eth_dst'], eth_dst_hairpin_table, self.pipeline,
             self.dp.timeout, self.dp.learn_jitter, self.dp.learn_ban_timeout,
             self.dp.cache_update_guard_time, self.dp.idle_dst, self.dp.stack,
-            self.dp.has_externals)
+            self.dp.has_externals, self.dp.stack_root_flood_reflection)
         if any(t in self.dp.tables for t in ('port_acl', 'vlan_acl', 'egress_acl'))\
                 or self.dp.tunnel_acls:
             self.acl_manager = valve_acl.ValveAclManager(

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -307,7 +307,7 @@ class ValveFloodStackManager(ValveFloodManager):
                  combinatorial_port_flood, canonical_port_order,
                  stack_ports, has_externals,
                  dp_shortest_path_to_root, shortest_path_port,
-                 longest_path_to_root_len, is_stack_root,
+                 stack_root_flood_reflection, is_stack_root,
                  is_stack_root_candidate, graph):
         super(ValveFloodStackManager, self).__init__(
             logger, flood_table, pipeline,
@@ -319,16 +319,13 @@ class ValveFloodStackManager(ValveFloodManager):
         self.externals = has_externals
         self.shortest_path_port = shortest_path_port
         self.dp_shortest_path_to_root = dp_shortest_path_to_root
-        self.longest_path_to_root_len = longest_path_to_root_len
         self.is_stack_root = is_stack_root
         self.is_stack_root_candidate = is_stack_root_candidate
         self.graph = graph
-        stack_size = self.longest_path_to_root_len()
-        if stack_size is not None and stack_size > 2:
-            self.logger.info('stack size %u' % stack_size)
+        self.stack_root_flood_reflection = stack_root_flood_reflection
+        if self.stack_root_flood_reflection:
             self._flood_actions_func = self._flood_actions
         else:
-            self.logger.info('stack size <= 2, using non root-reflection stacking')
             self._flood_actions_func = self._flood_actions_size2
         self._set_ext_port_flag = []
         self._set_nonext_port_flag = []

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -27,7 +27,7 @@ class ValveHostManager(ValveManagerBase):
     def __init__(self, logger, ports, vlans, eth_src_table, eth_dst_table,
                  eth_dst_hairpin_table, pipeline, learn_timeout, learn_jitter,
                  learn_ban_timeout, cache_update_guard_time, idle_dst, stack,
-                 has_externals):
+                 has_externals, stack_root_flood_reflection):
         self.logger = logger
         self.ports = ports
         self.vlans = vlans
@@ -45,6 +45,7 @@ class ValveHostManager(ValveManagerBase):
         self.idle_dst = idle_dst
         self.stack = stack
         self.has_externals = has_externals
+        self.stack_root_flood_reflection = stack_root_flood_reflection
         if self.eth_dst_hairpin_table:
             self.output_table = self.eth_dst_hairpin_table
 
@@ -301,7 +302,8 @@ class ValveHostManager(ValveManagerBase):
             # stacks of size > 2 will have an unknown MAC flooded towards the root,
             # and flooded down again. If we learned the MAC on a local port and
             # heard the reflected flooded copy, discard the reflection.
-            local_stack_learn = (port.stack and not cache_port.stack)
+            local_stack_learn = (
+                self.stack_root_flood_reflection and port.stack and not cache_port.stack)
             guard_time = self.cache_update_guard_time
             if cache_port == port or same_lag or local_stack_learn:
                 # aggressively re-learn on LAGs, and prefer recently learned

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -7360,20 +7360,22 @@ class FaucetSingleStackStringOf3DPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
         for int_host in int_hosts:
             # All internal hosts can reach other internal hosts.
             for other_int_host in int_hosts - {int_host}:
-                self.verify_broadcast(hosts=(int_host, other_int_host), broadcast_expected=True)
-                self.verify_unicast(hosts=(int_host, other_int_host), unicast_expected=True)
+                self.one_ipv4_ping(
+                    int_host, other_int_host.IP(), require_host_learned=False)
 
         for ext_host in ext_hosts:
             # All external hosts cannot flood to each other
             for other_ext_host in ext_hosts - {ext_host}:
-                self.verify_broadcast(hosts=(ext_host, other_ext_host), broadcast_expected=False)
+                self.verify_broadcast(
+                    hosts=(ext_host, other_ext_host), broadcast_expected=False)
 
         remote_ext_hosts = ext_hosts - set(root_ext_hosts)
         # int host should never be broadcast to an ext host that is not on the root.
         for local_int_hosts, _ in dp_hosts.values():
             local_int_host = list(local_int_hosts)[0]
             for remote_ext_host in remote_ext_hosts:
-                self.verify_broadcast(hosts=(local_int_host, remote_ext_host), broadcast_expected=False)
+                self.verify_broadcast(
+                    hosts=(local_int_host, remote_ext_host), broadcast_expected=False)
 
 
 class FaucetGroupStackStringOfDPUntaggedTest(FaucetStackStringOfDPUntaggedTest):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -8100,8 +8100,24 @@ class FaucetBadFlowModTest(FaucetUntaggedTest):
         return (max_port + offset) & mask
 
     def bad_match(self):
-        """Match with bad input port"""
-        return {'match': {'in_port': self.bad_port()}}
+        """Return a bad match field"""
+        matches = (
+            # Bad input port
+            {'in_port': self.bad_port()},
+            # IPv4 (broadcast) src with bad ('reserved') ethertype
+            {'nw_src': '255.255.255.255', 'dl_type': 0xFFFF},
+            # IPv4 with IPv6 ethertype:
+            {'nw_src': '1.2.3.4', 'dl_type': 0x86DD},
+            # IPv4 address as IPv6 dst
+            {'ipv6_dst': '1.2.3.4', 'dl_type': 0x86DD},
+            # IPv6 dst with Bad/reserved ip_proto
+            {'ipv6_dst': '2001::aaaa:bbbb:cccc:1111', 'ip_proto': 255},
+            # Destination port but no transport protocol
+            {'tp_dst': 80},
+            # ARP opcode on non-ARP packetx
+            {'arp_op': 0x3, 'dl_type': 0x1234})
+        match = random.sample(matches, 1)[0]
+        return {'match': match}
 
     def bad_actions(self, count=1):
         """Return a questionable actions parameter"""

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -2,6 +2,7 @@
 
 """Mininet tests for FAUCET."""
 
+# pylint: disable=too-many-lines
 # pylint: disable=missing-docstring
 # pylint: disable=too-many-arguments
 # pylint: disable=unbalanced-tuple-unpacking
@@ -122,9 +123,12 @@ vlans:
         description: "untagged"
 """
 
+    # pylint: disable=invalid-name
     CONFIG = CONFIG_BOILER_UNTAGGED
 
-    def setUp(self): # pylint: disable=invalid-name
+    EVENT_LOGGER_TIMEOUT = 120  # Timeout for event logger process
+
+    def setUp(self):  # pylint: disable=invalid-name
         super(FaucetUntaggedTest, self).setUp()
         self.topo = self.topo_class(
             self.OVS_TYPE, self.ports_sock, self._test_name(), [self.dpid],
@@ -157,8 +161,11 @@ vlans:
         event_log = os.path.join(self.tmpdir, 'event.log')
         controller = self._get_controller()
         sock = self.env['faucet']['FAUCET_EVENT_SOCK']
+        # Relying on a timeout seems a bit brittle;
+        # as an alternative we might possibly use something like
+        # `with popen(cmd...) as proc` to clean up on exceptions
         controller.cmd(mininet_test_util.timeout_cmd(
-            'nc -U %s > %s &' % (sock, event_log), 120))
+            'nc -U %s > %s &' % (sock, event_log), self.EVENT_LOGGER_TIMEOUT))
         self.ping_all_when_learned()
         self.flap_all_switch_ports()
         self.verify_traveling_dhcp_mac()
@@ -8164,3 +8171,50 @@ class FaucetBadFlowModTest(FaucetUntaggedTest):
             error('sending bad flow_mod', flow_mod, '\n')
             self.send_flow_mod(flow_mod)
         self.ping_all_when_learned()
+
+
+class FaucetUntaggedMorePortsBase(FaucetUntaggedTest):
+    """Base class for untagged test with more ports"""
+
+    # pylint: disable=invalid-name
+    N_UNTAGGED = 16  # Maximum number of ports to test
+    EVENT_LOGGER_TIMEOUT = 180  # Timeout for event logger process
+
+    # Config lines for additional ports
+    CONFIG_EXTRA_PORT = """
+            {port}:
+                native_vlan: 100""" + "\n"
+
+    def _init_faucet_config(self):  # pylint: disable=invalid-name
+        """Extend config with more ports if needed"""
+        self.assertTrue(self.CONFIG.endswith(CONFIG_BOILER_UNTAGGED))
+        # We know how to extend the config for more ports
+        base_port_count = len(re.findall('port', CONFIG_BOILER_UNTAGGED))
+        ports = self.topo.dpid_ports(self.dpid)
+        for port in ports[base_port_count:]:
+            self.CONFIG += self.CONFIG_EXTRA_PORT.format(port=port)
+        super()._init_faucet_config()
+
+    def setUp(self):
+        """Make sure N_UNTAGGED doesn't exceed hw port count"""
+        if self.config and self.config.get('hw_switch', False):
+            self.N_UNTAGGED = min(len(self.config['dp_ports']),
+                                  self.N_UNTAGGED)
+        error('(%d ports) ' % self.N_UNTAGGED)
+        super().setUp()
+
+
+class FaucetUntagged32PortTest(FaucetUntaggedMorePortsBase):
+    """Untagged test with up to 32 ports"""
+
+    # pylint: disable=invalid-name
+    N_UNTAGGED = 32  # Maximum number of ports to test
+
+
+@unittest.skip('slow and potentially unreliable on travis')
+class FaucetUntagged48PortTest(FaucetUntaggedMorePortsBase):
+    """Untagged test with up to 48 ports"""
+
+    # pylint: disable=invalid-name
+    N_UNTAGGED = 48  # Maximum number of ports to test
+    EVENT_LOGGER_TIMEOUT = 360  # Timeout for event logger process

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -7360,6 +7360,9 @@ class FaucetSingleStackStringOf3DPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
         for int_host in int_hosts:
             # All internal hosts can reach other internal hosts.
             for other_int_host in int_hosts - {int_host}:
+                # force ARP to test broadcast.
+                int_host.cmd(
+                    'arp -d %s' % other_int_host.IP())
                 self.one_ipv4_ping(
                     int_host, other_int_host.IP(), require_host_learned=False)
 


### PR DESCRIPTION
If we repeatedly scrape these values and wait for tables that
will never appear, it can take a long time.